### PR TITLE
HHE propose some fixes

### DIFF
--- a/asyncio_glib/glib_selector.py
+++ b/asyncio_glib/glib_selector.py
@@ -43,7 +43,10 @@ class _SelectorSource(GLib.Source):
         for (fd, tag) in self._fd_to_tag.items():
             condition = self.query_unix_fd(tag)
             events = self._fd_to_events.setdefault(fd, 0)
-            if condition & GLib.IOCondition.IN:
+            if (
+              condition & GLib.IOCondition.IN
+              or condition & GLib.IOCondition.HUP
+            ):
                 events |= selectors.EVENT_READ
             if condition & GLib.IOCondition.OUT:
                 events |= selectors.EVENT_WRITE


### PR DESCRIPTION
Fixes optional signint override;
`RawMainLoop = MainLoop.__bases__[0]` returns the type of MainLoop, seems to be due to a name conflict with it's super (also called GLib.MainLoop, be it in other file scope). This results in `handle_sigint` not really doing much, is stuck in True option regardless of its value.

Fixes blocking subprocess pipe;
Map `condition & GLib.IOCondition.HUP` to selector.EVENT_READ is required to fix this

